### PR TITLE
Fix CDI validation

### DIFF
--- a/implementation/src/main/java/org/wildfly/microprofile/config/inject/ConfigExtension.java
+++ b/implementation/src/main/java/org/wildfly/microprofile/config/inject/ConfigExtension.java
@@ -108,7 +108,9 @@ public class ConfigExtension implements Extension {
 
                 if (!config.getOptionalValue(key, (Class)type).isPresent()) {
                     String defaultValue = configProperty.defaultValue();
-                    if (defaultValue == null || defaultValue.length() == 0) {
+                    if (defaultValue == null ||
+                            defaultValue.length() == 0 ||
+                            defaultValue.equals(ConfigProperty.UNCONFIGURED_VALUE)) {
                         deploymentProblems.add("No Config Value exists for " + key);
                     }
                 }


### PR DESCRIPTION
During CDI validation, check whether a config's defaultValue is set to
ConfigProperty#UNCONFIGURED_VALUE and rejects the deployment if that's
the case.