### PR TITLE
ConfigProperty default name #233, no longer decapitalize the default derived name from a class

### DIFF
--- a/implementation/src/main/java/org/wildfly/microprofile/config/inject/ConfigExtension.java
+++ b/implementation/src/main/java/org/wildfly/microprofile/config/inject/ConfigExtension.java
@@ -134,8 +134,6 @@ public class ConfigExtension implements Extension {
             AnnotatedType declaringType = member.getDeclaringType();
             if (declaringType != null) {
                 String[] parts = declaringType.getJavaClass().getCanonicalName().split("\\.");
-                String cn = parts[parts.length-1];
-                parts[parts.length-1] = Character.toLowerCase(cn.charAt(0)) + (cn.length() > 1 ? cn.substring(1) : "");
                 StringBuilder sb = new StringBuilder(parts[0]);
                 for (int i = 1; i < parts.length; i++) {
                     sb.append(".").append(parts[i]);


### PR DESCRIPTION
There was a change in behavior regarding the default name of a @ConfigProperty that no longer decapitalizes the class name of the injection site:
https://github.com/eclipse/microprofile-config/issues/233

Prior to this update, the CDIPlainInjectionTest was failing to deploy due to no org.eclipse.microprofile.config.tck.CDIPlainInjectionTest.defaultPropertyBean.configProperty config value being found:

```
Sep 15, 2017 8:13:21 PM org.apache.webbeans.portable.events.discovery.ErrorStack logErrors
SEVERE: Error while validating Configuration
No Config Value exists for org.eclipse.microprofile.config.tck.CDIPlainInjectionTest.defaultPropertyBean.configProperty
javax.enterprise.inject.spi.DeploymentException: Error while validating Configuration
No Config Value exists for org.eclipse.microprofile.config.tck.CDIPlainInjectionTest.defaultPropertyBean.configProperty
	at org.wildfly.microprofile.config.inject.ConfigExtension.validate(ConfigExtension.java:122)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.webbeans.event.ObserverMethodImpl.invoke(ObserverMethodImpl.java:347)

```

The test is now setting this value using the key org.eclipse.microprofile.config.tck.CDIPlainInjectionTest.DefaultPropertyBean.configProperty.

With this PR, the TCK is completely passing.

Signed-off-by: Scott Stark <starksm64@gmail.com>