### PR TITLE
Add ConfigProviderService

### DIFF
--- a/extension/src/main/java/org/wildfly/extension/microprofile/config/ConfigProviderService.java
+++ b/extension/src/main/java/org/wildfly/extension/microprofile/config/ConfigProviderService.java
@@ -22,44 +22,42 @@
 
 package org.wildfly.extension.microprofile.config;
 
-import static org.wildfly.extension.microprofile.config.ServiceNames.CONFIG_SOURCE_PROVIDER;
-
-import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.msc.service.Service;
-import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
+import org.wildfly.microprofile.config.WildFlyConfigProviderResolver;
 
 /**
  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2017 Red Hat inc.
  */
-public class ConfigSourceProviderService implements Service<ConfigSourceProvider> {
+public class ConfigProviderService implements Service<ConfigProviderResolver> {
 
-    private final ConfigSourceProvider configSourceProvider;
+    private ConfigProviderService() {
 
-    public ConfigSourceProviderService(String name, ConfigSourceProvider configSourceProvider) {
-        this.configSourceProvider = configSourceProvider;
     }
 
-    public static void install(OperationContext context, String name, ConfigSourceProvider configSourceProvider) {
-        ConfigSourceProviderService service = new ConfigSourceProviderService(name, configSourceProvider);
-        ServiceBuilder<ConfigSourceProvider> serviceBuilder = context.getServiceTarget().addService(CONFIG_SOURCE_PROVIDER.append(name), service);
-        serviceBuilder.install();
-    }
-
-    @Override
-    public void start(StartContext startContext) throws StartException {
+    static void install(OperationContext context) {
+        ConfigProviderService service = new ConfigProviderService();
+        context.getServiceTarget().addService(ServiceNames.CONFIG_PROVIDER, service)
+                .install();
     }
 
     @Override
-    public void stop(StopContext stopContext) {
+    public void start(StartContext context) throws StartException {
+        ConfigProviderResolver.setInstance(WildFlyConfigProviderResolver.INSTANCE);
     }
 
     @Override
-    public ConfigSourceProvider getValue() throws IllegalStateException, IllegalArgumentException {
-        return configSourceProvider;
+    public void stop(StopContext context) {
+        ConfigProviderResolver.setInstance(null);
+
     }
 
+    @Override
+    public ConfigProviderResolver getValue() throws IllegalStateException, IllegalArgumentException {
+        return WildFlyConfigProviderResolver.INSTANCE;
+    }
 }

--- a/extension/src/main/java/org/wildfly/extension/microprofile/config/ConfigSourceDefinition.java
+++ b/extension/src/main/java/org/wildfly/extension/microprofile/config/ConfigSourceDefinition.java
@@ -128,7 +128,7 @@ public class ConfigSourceDefinition extends PersistentResourceDefinition {
                     @Override
                     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
                         String name = context.getCurrentAddressValue();
-                        context.removeService(ConfigSourceService.SERVICE_NAME.append(name));
+                        context.removeService(ServiceNames.CONFIG_SOURCE.append(name));
                     }
                 });
     }

--- a/extension/src/main/java/org/wildfly/extension/microprofile/config/ConfigSourceProviderDefinition.java
+++ b/extension/src/main/java/org/wildfly/extension/microprofile/config/ConfigSourceProviderDefinition.java
@@ -98,7 +98,7 @@ public class ConfigSourceProviderDefinition extends PersistentResourceDefinition
                     @Override
                     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
                         String name = context.getCurrentAddressValue();
-                        context.removeService(ConfigSourceProviderService.SERVICE_NAME.append(name));
+                        context.removeService(ServiceNames.CONFIG_SOURCE_PROVIDER.append(name));
                     }
                 });
     }

--- a/extension/src/main/java/org/wildfly/extension/microprofile/config/ConfigSourceService.java
+++ b/extension/src/main/java/org/wildfly/extension/microprofile/config/ConfigSourceService.java
@@ -27,7 +27,6 @@ import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceBuilder;
-import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
@@ -40,8 +39,6 @@ public class ConfigSourceService implements Service<ConfigSource> {
 
     private final InjectedValue<PathHandler> pathHandlerInjectedValue = new InjectedValue<>();
 
-    public static final ServiceName SERVICE_NAME = ServiceName.JBOSS.append("eclipse", "microprofile", "config", "config-source");
-
     private final String name;
     private final ConfigSource configSource;
 
@@ -52,7 +49,7 @@ public class ConfigSourceService implements Service<ConfigSource> {
 
     static void install(OperationContext context, String name, ConfigSource configSource) {
         ConfigSourceService service = new ConfigSourceService(name, configSource);
-        ServiceBuilder<ConfigSource> serviceBuilder = context.getServiceTarget().addService(SERVICE_NAME.append(name), service);
+        ServiceBuilder<ConfigSource> serviceBuilder = context.getServiceTarget().addService(ServiceNames.CONFIG_SOURCE.append(name), service);
         serviceBuilder.install();
     }
     @Override

--- a/extension/src/main/java/org/wildfly/extension/microprofile/config/ServiceNames.java
+++ b/extension/src/main/java/org/wildfly/extension/microprofile/config/ServiceNames.java
@@ -1,0 +1,16 @@
+package org.wildfly.extension.microprofile.config;
+
+import org.jboss.msc.service.ServiceName;
+
+/**
+ * Service Names for Eclipse MicroProfile Config objects.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2017 Red Hat inc.
+ */
+public interface ServiceNames {
+    ServiceName MICROPROFILE_CONFIG = ServiceName.JBOSS.append("eclipse", "microprofile", "config");
+
+    ServiceName CONFIG_PROVIDER = MICROPROFILE_CONFIG.append("config-provider");
+    ServiceName CONFIG_SOURCE = MICROPROFILE_CONFIG.append("config-source");
+    ServiceName CONFIG_SOURCE_PROVIDER = MICROPROFILE_CONFIG.append("config-source-provider");
+}

--- a/extension/src/main/java/org/wildfly/extension/microprofile/config/SubsystemAdd.java
+++ b/extension/src/main/java/org/wildfly/extension/microprofile/config/SubsystemAdd.java
@@ -1,15 +1,13 @@
 package org.wildfly.extension.microprofile.config;
 
-import org.wildfly.microprofile.config.WildFlyConfigProviderResolver;
-import org.wildfly.extension.microprofile.config.deployment.DependencyProcessor;
-import org.wildfly.extension.microprofile.config.deployment.SubsystemDeploymentProcessor;
-import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.server.AbstractDeploymentChainStep;
 import org.jboss.as.server.DeploymentProcessorTarget;
 import org.jboss.dmr.ModelNode;
+import org.wildfly.extension.microprofile.config.deployment.DependencyProcessor;
+import org.wildfly.extension.microprofile.config.deployment.SubsystemDeploymentProcessor;
 
 /**
  * Handler responsible for adding the subsystem resource to the model
@@ -39,6 +37,8 @@ class SubsystemAdd extends AbstractBoottimeAddStepHandler {
 
         MicroProfileConfigLogger.ROOT_LOGGER.activatingSubsystem();
 
+        ConfigProviderService.install(context);
+
         //Add deployment processors here
         //Remove this if you don't need to hook into the deployers, or you can add as many as you like
         //see SubDeploymentProcessor for explanation of the phases
@@ -50,6 +50,5 @@ class SubsystemAdd extends AbstractBoottimeAddStepHandler {
             }
         }, OperationContext.Stage.RUNTIME);
 
-        ConfigProviderResolver.setInstance(WildFlyConfigProviderResolver.INSTANCE);
     }
 }

--- a/extension/src/main/java/org/wildfly/extension/microprofile/config/SubsystemRemove.java
+++ b/extension/src/main/java/org/wildfly/extension/microprofile/config/SubsystemRemove.java
@@ -20,8 +20,7 @@ class SubsystemRemove extends AbstractRemoveStepHandler {
 
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
-        //Remove any services installed by the corresponding add handler here
-        //context.removeService(ServiceName.of("some", "name"));
+        context.removeService(ServiceNames.CONFIG_PROVIDER);
     }
 
 

--- a/extension/src/main/java/org/wildfly/extension/microprofile/config/deployment/SubsystemDeploymentProcessor.java
+++ b/extension/src/main/java/org/wildfly/extension/microprofile/config/deployment/SubsystemDeploymentProcessor.java
@@ -2,16 +2,11 @@ package org.wildfly.extension.microprofile.config.deployment;
 
 import java.util.List;
 
-import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
-import org.wildfly.extension.microprofile.config.ConfigSourceProviderService;
-import org.wildfly.extension.microprofile.config.ConfigSourceService;
-import org.wildfly.microprofile.config.WildFlyConfigBuilder;
-import org.wildfly.microprofile.config.WildFlyConfigProviderResolver;
-import org.wildfly.microprofile.config.inject.ConfigExtension;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.spi.ConfigBuilder;
 import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
 import org.jboss.as.ee.weld.WeldDeploymentMarker;
 import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
@@ -25,6 +20,10 @@ import org.jboss.modules.Module;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceRegistry;
+import org.wildfly.extension.microprofile.config.ServiceNames;
+import org.wildfly.microprofile.config.WildFlyConfigBuilder;
+import org.wildfly.microprofile.config.WildFlyConfigProviderResolver;
+import org.wildfly.microprofile.config.inject.ConfigExtension;
 
 /**
  */
@@ -69,11 +68,11 @@ public class SubsystemDeploymentProcessor implements DeploymentUnitProcessor {
     private void addConfigSourcesFromServices(ConfigBuilder builder, ServiceRegistry serviceRegistry, ClassLoader classloader) {
         List<ServiceName> serviceNames = serviceRegistry.getServiceNames();
         for (ServiceName serviceName: serviceNames) {
-            if (ConfigSourceService.SERVICE_NAME.isParentOf(serviceName)) {
+            if (ServiceNames.CONFIG_SOURCE.isParentOf(serviceName)) {
                 ServiceController<?> service = serviceRegistry.getService(serviceName);
                 ConfigSource configSource = ConfigSource.class.cast(service.getValue());
                 builder.withSources(configSource);
-            } else if (ConfigSourceProviderService.SERVICE_NAME.isParentOf(serviceName)) {
+            } else if (ServiceNames.CONFIG_SOURCE_PROVIDER.isParentOf(serviceName)) {
                 ServiceController<?> service = serviceRegistry.getService(serviceName);
                 ConfigSourceProvider configSourceProvider = ConfigSourceProvider.class.cast(service.getValue());
                 for (ConfigSource configSource : configSourceProvider.getConfigSources(classloader)) {


### PR DESCRIPTION
The ConfigProviderService provides a MSC Service that can be used to
ensure that the Eclipse MicroProfile ConfigProvider is properly setup
before using it in other runtime services.

Its service name is: jboss.eclipse.microprofile.config.config-provider
(as specified in ServiceNames.CONFIG_PROVIDER).