### PR TITLE
[MP-Config] add missing module dependency

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/config/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/config/main/module.xml
@@ -19,5 +19,6 @@
         <module name="org.jboss.as.ee" />
         <module name="org.wildfly.extension.undertow" />
         <module name="javax.enterprise.api" />
+        <module name="javax.annotation.api" />
     </dependencies>
 </module>


### PR DESCRIPTION
javax.annotation.api is required to be able to load the @PriorityAnnotation