### PR TITLE
[MP-CONFIG] convert env var name

### DIFF
--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -59,6 +59,10 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.16</version>
                 <configuration>
+                    <environmentVariables>
+                        <!-- Used by EnvConfigSourceTestCase -->
+                        <WILDFLY_MP_CONFIG_PROP>1234</WILDFLY_MP_CONFIG_PROP>
+                    </environmentVariables>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <enableAssertions>true</enableAssertions>
                     <argLine>-Xmx512m</argLine>

--- a/implementation/src/main/java/org/wildfly/microprofile/config/EnvConfigSource.java
+++ b/implementation/src/main/java/org/wildfly/microprofile/config/EnvConfigSource.java
@@ -25,7 +25,6 @@ package org.wildfly.microprofile.config;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Map;
-import java.util.UUID;
 
 import org.eclipse.microprofile.config.spi.ConfigSource;
 
@@ -49,7 +48,26 @@ public class EnvConfigSource implements ConfigSource, Serializable {
 
     @Override
     public String getValue(String name) {
-        return System.getenv(name);
+        if (name == null) {
+            return null;
+        }
+
+        String envVarName = name;
+        // exact match
+        if (System.getenv().containsKey(envVarName)) {
+            return System.getenv(envVarName);
+        }
+        // replace dots by underscores
+        envVarName = envVarName.replace('.', '_');
+        if (System.getenv().containsKey(envVarName)) {
+            return System.getenv(envVarName);
+        }
+        // replace dots by underscores and use upper case
+        envVarName = envVarName.toUpperCase();
+        if (System.getenv().containsKey(envVarName)) {
+            return System.getenv(envVarName);
+        }
+        return null;
     }
 
     @Override

--- a/implementation/src/test/java/org/wildfly/microprofile/config/EnvConfigSourceTestCase.java
+++ b/implementation/src/test/java/org/wildfly/microprofile/config/EnvConfigSourceTestCase.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.microprofile.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.junit.Test;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2018 Red Hat inc.
+ */
+public class EnvConfigSourceTestCase {
+
+        @Test
+        public void testConversionOfEnvVariableNames() {
+                String envProp = System.getenv("WILDFLY_MP_CONFIG_PROP");
+                assertNotNull(envProp);
+
+                ConfigSource cs = new EnvConfigSource();
+                assertEquals(envProp, cs.getValue("WILDFLY_MP_CONFIG_PROP"));
+                // the config source returns only the name of the actual env variable
+                assertTrue(cs.getPropertyNames().contains("WILDFLY_MP_CONFIG_PROP"));
+
+                assertEquals(envProp, cs.getValue("wildfly_mp_config_prop"));
+                assertFalse(cs.getPropertyNames().contains("wildfly_mp_config_prop"));
+
+                assertEquals(envProp, cs.getValue("wildfly.mp.config.prop"));
+                assertFalse(cs.getPropertyNames().contains("wildfly.mp.config.prop"));
+
+                assertEquals(envProp, cs.getValue("WILDFLY.MP.CONFIG.PROP"));
+                // the config source returns only the name of the actual env variable
+                assertFalse(cs.getPropertyNames().contains("WILDFLY.MP.CONFIG.PROP"));
+        }
+}


### PR DESCRIPTION
Support mapping rule for environment variable name.
A given mp-config property name can map to several environment
variables:

* exact match (foo -> foo)
* replace . by _ (foo.size -> foo_size)
* replace . by _ and upper case (foo.size -> FOO_SIZE)

This closes #36.