### PR TITLE
Replace special chars when looking in env vars

### DIFF
--- a/implementation/src/main/java/org/wildfly/microprofile/config/EnvConfigSource.java
+++ b/implementation/src/main/java/org/wildfly/microprofile/config/EnvConfigSource.java
@@ -49,7 +49,16 @@ public class EnvConfigSource implements ConfigSource, Serializable {
 
     @Override
     public String getValue(String name) {
-        return System.getenv(name);
+        String value = System.getenv(name);
+        if (value != null) {
+            return value;
+        }
+        name = name.replaceAll("[^a-zA-Z0-9_]", "_");
+        value = System.getenv(name);
+        if (value != null) {
+            return value;
+        }
+        return System.getenv(name.toUpperCase());
     }
 
     @Override


### PR DESCRIPTION
Miicroprofile spec (https://github.com/eclipse/microprofile-config/blob/master/spec/src/main/asciidoc/configsources.asciidoc#default-configsources) now tries to aligne differences among naming standards between Java props and env vars. This PR follows the pre-scribed rules for name estimation.