### PR TITLE
Fixes #43

### DIFF
--- a/implementation/src/main/java/org/wildfly/microprofile/config/inject/ConfigProducer.java
+++ b/implementation/src/main/java/org/wildfly/microprofile/config/inject/ConfigProducer.java
@@ -179,7 +179,7 @@ public class ConfigProducer implements Serializable{
                 return optionalValue.get();
             } else {
                 String defaultValue = getDefaultValue(injectionPoint);
-                if (defaultValue != null) {
+                if (defaultValue != null && !defaultValue.equals(ConfigProperty.UNCONFIGURED_VALUE)) {
                     return ((WildFlyConfig)config).convert(defaultValue, target);
                 } else {
                     return null;

--- a/testsuite/wildfly/src/test/java/org/wildfly/extension/microprofile/config/AssertUtils.java
+++ b/testsuite/wildfly/src/test/java/org/wildfly/extension/microprofile/config/AssertUtils.java
@@ -30,7 +30,7 @@ import org.junit.Assert;
 public class AssertUtils {
 
     public static void assertTextContainsProperty(String text, String propName, Object propValue) {
-        Assert.assertTrue("Property not found in " + text,
+        Assert.assertTrue("Property " + propName + " not found in " + text,
                 text.contains(propName + " = " + propValue));
     }
 }

--- a/testsuite/wildfly/src/test/java/org/wildfly/extension/microprofile/config/app/microprofile/MicroProfileConfigTestCase.java
+++ b/testsuite/wildfly/src/test/java/org/wildfly/extension/microprofile/config/app/microprofile/MicroProfileConfigTestCase.java
@@ -76,6 +76,7 @@ public class MicroProfileConfigTestCase {
             assertTextContainsProperty(text, "my.prop.never.defined", Optional.empty().toString());
             assertTextContainsProperty(text, "my.prop", "BAR");
             assertTextContainsProperty(text, "my.other.prop", false);
+            assertTextContainsProperty(text, "optional.injected.prop.that.is.not.configured", Optional.empty().toString());
             assertTextContainsProperty(text, MY_PROP_FROM_SUBSYSTEM_PROP_NAME, MY_PROP_FROM_SUBSYSTEM_PROP_VALUE);
         }
     }

--- a/testsuite/wildfly/src/test/java/org/wildfly/extension/microprofile/config/app/microprofile/TestApplication.java
+++ b/testsuite/wildfly/src/test/java/org/wildfly/extension/microprofile/config/app/microprofile/TestApplication.java
@@ -61,6 +61,10 @@ public class TestApplication extends Application {
         @ConfigProperty(name = MY_PROP_FROM_SUBSYSTEM_PROP_NAME)
         String prop3;
 
+        @Inject
+        @ConfigProperty(name = "optional.injected.prop.that.is.not.configured")
+        Optional<String> optionalProp;
+
         @GET
         @Produces("text/plain")
         public Response doGet() {
@@ -69,6 +73,7 @@ public class TestApplication extends Application {
             text.append("my.prop.never.defined = " + foo + "\n");
             text.append("my.prop = " + prop1 + "\n");
             text.append("my.other.prop = " + prop2 + "\n");
+            text.append("optional.injected.prop.that.is.not.configured = " + optionalProp + "\n");
             text.append(MY_PROP_FROM_SUBSYSTEM_PROP_NAME + " = " + prop3 + "\n");
             return Response.ok(text).build();
         }


### PR DESCRIPTION
If the default value is ConfigProperty.UNCONFIGURED_VALUE, an injected
Optional should be set to Optional.empty